### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :item_find, only: [:show, :edit, :update]
-  before_action :trans_index, only: [:edit]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :destroy]
+  before_action :item_find, only: [:show, :edit, :update, :destroy]
+  before_action :trans_index, only: [:edit, :destroy]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -32,6 +32,11 @@ class ItemsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user.id %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete }, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>


### PR DESCRIPTION
# what
・商品削除機能を実装

# why
・商品を後から削除できるようにするため

Gyazo
・ログイン状態の出品者が詳細ページの削除ボタンを押すと商品を削除できる
https://gyazo.com/aa23a92356bcf6e8c080233e0868bc7e